### PR TITLE
attr_expose

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    controlled_exposure (1.0.0)
+    controlled_exposure (2.0.0)
+      activesupport (>= 4.2.0)
       railties (>= 4.2.0)
 
 GEM
@@ -26,14 +27,18 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
     builder (3.2.4)
-    byebug (11.1.3)
-    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
+    debug (1.7.2)
+      irb (>= 1.5.0)
+      reline (>= 0.3.1)
     docile (1.4.0)
     erubi (1.12.0)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
+    io-console (0.6.0)
+    irb (1.6.4)
+      reline (>= 0.3.0)
     loofah (2.19.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -43,12 +48,6 @@ GEM
     nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    pry (0.14.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
     racc (1.6.2)
     rack (2.2.6.4)
     rack-test (2.1.0)
@@ -66,6 +65,8 @@ GEM
       thor (~> 1.0)
       zeitwerk (~> 2.5)
     rake (13.0.6)
+    reline (0.3.3)
+      io-console (~> 0.5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -83,9 +84,8 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 2.0)
   controlled_exposure!
+  debug
   minitest (~> 5.0)
-  pry-byebug
-  railties (>= 4.2.0)
   rake (~> 13.0)
   simplecov
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,4 +90,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.1.4
+   2.4.12

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 explicit expose rails controller `@instance` variables as helpers in views. optional prevent all access to `@instance` variables in views.
 
+
+## Changes
+
+### 2.0
+- add `attr_expose`
+- add `def_expose`
+- deprecate `expose`
+- this is now based on `ActiveSupport::Concern`
+
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -25,10 +35,11 @@ in your controller `app/controllers/hello_controller.rb`
 ```ruby
 class HelloController < ApplicationController
   enforce_expose!
-  expose :foo
+  attr_expose :foo, :bar
 
   def show
-    @foo = 'Hello World'
+    @foo = 'Hello'
+    self.bar = 'World!'
   end
 end
 ```
@@ -36,21 +47,46 @@ end
 and `app/views/hello/show.html.erb`
 
 ```ruby
-<%= foo %>
+<%= foo %><%= bar %>
 ```
 
 instead of
 
 ```ruby
-<%= @foo %>
+<%= @foo %><%= @bar %>
 ```
 
-### All Controllers
+
+There is also a `def_expose`
+
+```ruby
+class HelloController < ApplicationController
+  def_expose :foobar do
+    "Hello World!"
+  end
+end
+```
+
+which is a shorthand for
+
+```
+class HelloController < ApplicationController
+  def foobar
+    "Hello World!"
+  end
+
+  helper_method :foobar
+  protected_method :foobar
+end
+
+```
+
+### Enable for All Controllers
 
 ```ruby
 class ApplicationController < ActionController::Base
   enforce_expose!
-  expose :foo
+  attr_expose :foo
 end
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,10 @@
-require "bundler/gem_tasks"
-require "rake/testtask"
+require 'bundler/gem_tasks'
+require 'rake/testtask'
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << "test"
-  t.libs << "lib"
-  t.test_files = FileList["test/**/*_test.rb"]
+  t.libs << 'test'
+  t.libs << 'lib'
+  t.test_files = FileList['test/**/*_test.rb']
 end
 
 task :default => :test

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'controlled_exposure'

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "controlled_exposure"
+require 'bundler/setup'
+require 'controlled_exposure'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,5 @@ require "controlled_exposure"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/controlled_exposure.gemspec
+++ b/controlled_exposure.gemspec
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/controlled_exposure.gemspec
+++ b/controlled_exposure.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'railties', '>= 4.2.0'
+  spec.add_dependency 'activesupport', '~> 3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'minitest', '~> 5.0'

--- a/controlled_exposure.gemspec
+++ b/controlled_exposure.gemspec
@@ -34,12 +34,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'activesupport', '>= 4.2.0'
   spec.add_runtime_dependency 'railties', '>= 4.2.0'
-  spec.add_dependency 'activesupport', '~> 3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'debug'
   spec.add_development_dependency 'minitest', '~> 5.0'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'simplecov'
 end

--- a/controlled_exposure.gemspec
+++ b/controlled_exposure.gemspec
@@ -1,27 +1,27 @@
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "controlled_exposure/version"
+require 'controlled_exposure/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "controlled_exposure"
+  spec.name          = 'controlled_exposure'
   spec.version       = ControlledExposure::VERSION
-  spec.authors       = ["Stephan Zalewski"]
-  spec.email         = ["stephan+github@stzal.com"]
+  spec.authors       = ['Stephan Zalewski']
+  spec.email         = ['stephan+github@stzal.com']
 
   spec.summary       = %q{controll exposure of instance variables in rails views}
   spec.description   = %q{prevent automatic access to controller instance variables and enforce exposure via helper methods}
-  spec.homepage      = "https://github.com/stepahn/controlled_exposure"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/stepahn/controlled_exposure'
+  spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["homepage_uri"] = spec.homepage
-    spec.metadata["source_code_uri"] = spec.homepage
+    spec.metadata['homepage_uri'] = spec.homepage
+    spec.metadata['source_code_uri'] = spec.homepage
   else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
   end
 
   # Specify which files should be added to the gem when it is released.
@@ -29,16 +29,16 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency "railties", ">= 4.2.0"
+  spec.add_runtime_dependency 'railties', '>= 4.2.0'
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "railties", ">= 4.2.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "simplecov"
+  spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'minitest', '~> 5.0'
+  spec.add_development_dependency 'pry-byebug'
+  spec.add_development_dependency 'railties', '>= 4.2.0'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'simplecov'
 end

--- a/controlled_exposure.gemspec
+++ b/controlled_exposure.gemspec
@@ -38,9 +38,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activesupport', '~> 3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
+  spec.add_development_dependency 'debug'
   spec.add_development_dependency 'minitest', '~> 5.0'
-  spec.add_development_dependency 'pry-byebug'
-  spec.add_development_dependency 'railties', '>= 4.2.0'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'simplecov'
 end

--- a/controlled_exposure.gemspec
+++ b/controlled_exposure.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'controlled_exposure/version'
 
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Stephan Zalewski']
   spec.email         = ['stephan+github@stzal.com']
 
-  spec.summary       = %q{controll exposure of instance variables in rails views}
-  spec.description   = %q{prevent automatic access to controller instance variables and enforce exposure via helper methods}
+  spec.summary       = 'controll exposure of instance variables in rails views'
+  spec.description   = 'prevent automatic access to controller instance variables and enforce exposure via helper methods'
   spec.homepage      = 'https://github.com/stepahn/controlled_exposure'
   spec.license       = 'MIT'
 
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = 'exe'

--- a/lib/controlled_exposure/enforce.rb
+++ b/lib/controlled_exposure/enforce.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ControlledExposure
   module Enforce
     protected

--- a/lib/controlled_exposure/enforce.rb
+++ b/lib/controlled_exposure/enforce.rb
@@ -2,6 +2,8 @@
 
 module ControlledExposure
   module Enforce
+    extend ActiveSupport::Concern
+
     protected
 
     def view_assigns

--- a/lib/controlled_exposure/expose.rb
+++ b/lib/controlled_exposure/expose.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ControlledExposure
   module Expose
     private

--- a/lib/controlled_exposure/expose.rb
+++ b/lib/controlled_exposure/expose.rb
@@ -16,6 +16,14 @@ module ControlledExposure
         include ControlledExposure::Enforce
       end
 
+      def def_expose(method, &block)
+        define_method(method, &block)
+
+        protected(method)
+
+        helper_method(method)
+      end
+
       def attr_expose(*args)
         args.each do |attr|
           attr_accessor(attr)

--- a/lib/controlled_exposure/expose.rb
+++ b/lib/controlled_exposure/expose.rb
@@ -8,19 +8,23 @@ module ControlledExposure
 
     class_methods do
       def expose(attr)
-        attr_accessor attr
-        helper_method attr
-        protected attr
+        ActiveSupport::Deprecation.warn('.expose is deprecated. Use .attr_expose instead.')
+        attr_expose(attr)
       end
 
       def enforce_expose!
         include ControlledExposure::Enforce
       end
 
-    def expose(attr)
-      attr_accessor attr
-      helper_method attr
-      protected attr
+      def attr_expose(*args)
+        args.each do |attr|
+          attr_accessor(attr)
+
+          protected(attr)
+
+          helper_method(attr)
+        end
+      end
     end
   end
 end

--- a/lib/controlled_exposure/expose.rb
+++ b/lib/controlled_exposure/expose.rb
@@ -2,11 +2,20 @@
 
 module ControlledExposure
   module Expose
+    extend ActiveSupport::Concern
+
     private
 
-    def enforce_expose!
-      include ControlledExposure::Enforce
-    end
+    class_methods do
+      def expose(attr)
+        attr_accessor attr
+        helper_method attr
+        protected attr
+      end
+
+      def enforce_expose!
+        include ControlledExposure::Enforce
+      end
 
     def expose(attr)
       attr_accessor attr

--- a/lib/controlled_exposure/railtie.rb
+++ b/lib/controlled_exposure/railtie.rb
@@ -7,7 +7,7 @@ module ControlledExposure
   class Railtie < ::Rails::Railtie
     initializer 'controller_exposer.include_expose' do
       ActiveSupport.on_load :action_controller do
-        extend ControlledExposure::Expose
+        include ControlledExposure::Expose
       end
     end
   end

--- a/lib/controlled_exposure/version.rb
+++ b/lib/controlled_exposure/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ControlledExposure
-  VERSION = '1.0.0'
+  VERSION = '2.0.0'
 end

--- a/test/controlled_exposure_integration_test.rb
+++ b/test/controlled_exposure_integration_test.rb
@@ -29,7 +29,11 @@ class ControlledExposureIntegrationTest < ActionDispatch::IntegrationTest
     assert_response_body('/test_expose', 'TEST_STRING', text: 'TEST_STRING')
   end
 
-  def test_expose_ivar
-    assert_response_body('/test_expose_ivar', 'TEST_STRING', text: 'TEST_STRING')
+  def test_unenforced_attr_expose
+    assert_response_body('/test_unenforced_attr_expose', 'TEST_STRING', text: 'TEST_STRING')
+  end
+
+  def test_unenforced_ivar
+    assert_response_body('/test_unenforced_ivar', 'TEST_STRING', text: 'TEST_STRING')
   end
 end

--- a/test/controlled_exposure_integration_test.rb
+++ b/test/controlled_exposure_integration_test.rb
@@ -3,25 +3,29 @@
 require 'test_helper'
 
 class ControlledExposureIntegrationTest < ActionDispatch::IntegrationTest
-  def assert_response_body(path, text, expected)
-    get path, params: { txt: text }
+  def assert_response_body(path, expected, text: nil, params: { txt: text })
+    get path, params: params
     assert_response :success
     assert_equal(expected, response.parsed_body)
   end
 
+  def test_attr_expose
+    assert_response_body('/test_attr_expose', 'TEST_BAR|TEST_BAZ', params: { bar: 'TEST_BAR', baz: 'TEST_BAZ' })
+  end
+
   def test_enforce
-    assert_response_body('/test_enforce', 'TEST_STRING', '')
+    assert_response_body('/test_enforce', '', text: 'TEST_STRING')
   end
 
   def test_enforce_helper
-    assert_response_body('/test_enforce_helper', 'TEST_STRING', '')
+    assert_response_body('/test_enforce_helper', '', text: 'TEST_STRING')
   end
 
   def test_expose
-    assert_response_body('/test_expose', 'TEST_STRING', 'TEST_STRING')
+    assert_response_body('/test_expose', 'TEST_STRING', text: 'TEST_STRING')
   end
 
   def test_expose_ivar
-    assert_response_body('/test_expose_ivar', 'TEST_STRING', 'TEST_STRING')
+    assert_response_body('/test_expose_ivar', 'TEST_STRING', text: 'TEST_STRING')
   end
 end

--- a/test/controlled_exposure_integration_test.rb
+++ b/test/controlled_exposure_integration_test.rb
@@ -13,6 +13,10 @@ class ControlledExposureIntegrationTest < ActionDispatch::IntegrationTest
     assert_response_body('/test_attr_expose', 'TEST_BAR|TEST_BAZ', params: { bar: 'TEST_BAR', baz: 'TEST_BAZ' })
   end
 
+  def test_def_expose
+    assert_response_body('/test_def_expose', '|TEST_FOO|TEST_BAR|', params: { foo: 'TEST_FOO', bar: 'TEST_BAR' })
+  end
+
   def test_enforce
     assert_response_body('/test_enforce', '', text: 'TEST_STRING')
   end

--- a/test/deprecate_expose_test.rb
+++ b/test/deprecate_expose_test.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class DeprecateEposeTest < ActiveSupport::TestCase
+  def test_deprecation
+    assert_deprecated do
+      Class.new(ControlledExposureTestApp::ApplicationController) do
+        expose(:foo)
+      end
+    end
+  end
+end

--- a/test/rails_helper.rb
+++ b/test/rails_helper.rb
@@ -12,6 +12,8 @@ module ControlledExposureTestApp
     config.logger = Logger.new(StringIO.new)
 
     routes.append do
+      get '/test_attr_expose', to: 'controlled_exposure_test_app/enforce#test_attr_expose'
+      get '/test_def_expose', to: 'controlled_exposure_test_app/enforce#test_def_expose'
       get '/test_enforce', to: 'controlled_exposure_test_app/enforce#test_enforce'
       get '/test_enforce_helper', to: 'controlled_exposure_test_app/enforce#test_enforce_helper'
       get '/test_expose', to: 'controlled_exposure_test_app/enforce#test_expose'
@@ -25,32 +27,50 @@ end
 ControlledExposureTestApp::Application.initialize!
 
 module ControlledExposureTestApp
-  class EnforceController < ActionController::Base
-    def render_helper
-      render inline: '<%= foo %>'
+  class ApplicationController < ActionController::Base
+    def r(template)
+      render inline: template
     end
+  end
 
+  class EnforceController < ApplicationController
     enforce_expose!
     expose :foo
+    attr_expose :bar, :baz
+
+    def_expose :foobar do
+      "|#{params[:foo]}|#{params[:bar]}|"
+    end
+
+    def test_attr_expose
+      self.bar = params[:bar]
+      self.baz = params[:baz]
+
+      r '<%= bar %>|<%= baz %>'
+    end
+
+    def test_def_expose
+      r '<%= foobar %>'
+    end
 
     def test_enforce
       @bar = params[:txt]
-      render inline: '<%= @bar %>'
+      r '<%= @bar %>'
     end
 
     def test_enforce_helper
       self.foo = params[:txt]
-      render inline: '<%= @foo %>'
+      r '<%= @foo %>'
     end
 
     def test_expose
       self.foo = params[:txt]
-      render_helper
+      r '<%= foo %>'
     end
 
     def test_expose_ivar
       @foo = params[:txt]
-      render_helper
+      r '<%= foo %>'
     end
   end
 

--- a/test/rails_helper.rb
+++ b/test/rails_helper.rb
@@ -19,7 +19,8 @@ module ControlledExposureTestApp
       get '/test_expose', to: 'controlled_exposure_test_app/enforce#test_expose'
       get '/test_expose_ivar', to: 'controlled_exposure_test_app/enforce#test_expose_ivar'
       get '/test_expose_ivar', to: 'controlled_exposure_test_app/enforce#test_expose_ivar'
-      get '/test_unenforced_expose', to: 'controlled_exposure_test_app/unenforced#test_expose'
+      get '/test_unenforced_attr_expose', to: 'controlled_exposure_test_app/unenforced#test_attr_expose'
+      get '/test_unenforced_ivar', to: 'controlled_exposure_test_app/unenforced#test_unenforced_ivar'
     end
   end
 end
@@ -74,12 +75,17 @@ module ControlledExposureTestApp
     end
   end
 
-  class UnenforcedController < ActionController::Base
-    expose :foo
+  class UnenforcedController < ApplicationController
+    attr_expose :foo
 
-    def test_expose
+    def test_attr_expose
       self.foo = params[:txt]
-      render inline: '<%= foo %>'
+      r '<%= foo %>'
+    end
+
+    def test_unenforced_ivar
+      @foo = params[:txt]
+      r '<%= @foo %>'
     end
   end
 end

--- a/test/rails_helper.rb
+++ b/test/rails_helper.rb
@@ -36,7 +36,11 @@ module ControlledExposureTestApp
 
   class EnforceController < ApplicationController
     enforce_expose!
-    expose :foo
+
+    ActiveSupport::Deprecation.silence do
+      expose :foo
+    end
+
     attr_expose :bar, :baz
 
     def_expose :foobar do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,8 @@ SimpleCov.start do
   add_filter '/test/'
 end
 
+require 'debug'
+
 require 'minitest/autorun'
 
 require 'rails_helper'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'simplecov'
 SimpleCov.start do


### PR DESCRIPTION
- rubocop -a --only Style/StringLiterals
- rubocop -A --only Style/FrozenStringLiteralComment
- update loadpath syntax
- switch to ActiveSupport::Concern
- rename expose to attr_expose
- require debug gem
- update gems
- cleanuop gemspec
- add test for attr_expose
- add def_expose
- refactor tests for unenforced
- test depreation of `expose`
- silence deprecation warning
- update README
- bump version
- update bundler version
